### PR TITLE
Add support for integers in application name

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	environmentApplicationKeyRegex = `^[a-zA-Z-_]+\/[a-zA-Z-_]+\/[a-zA-Z-_0-9]+$`
-	environmentApplicationRegex    = `^[a-zA-Z-_]+\/[a-zA-Z-_]+\/[a-zA-Z-_0-9]*$`
+	environmentApplicationKeyRegex = `^[a-zA-Z-_]+\/[a-zA-Z-_0-9]+\/[a-zA-Z-_0-9]+$`
+	environmentApplicationRegex    = `^[a-zA-Z-_]+\/[a-zA-Z-_0-9]+\/[a-zA-Z-_0-9]*$`
 )
 
 // ValidateInputKey checks if cli input is valid

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -8,6 +8,7 @@ func TestValidateInputKey(t *testing.T) {
 		"STAGING/WeBapp/cockpit_api-pass",
 		"Integration/claim-score/elasticsearch_url",
 		"staging/webapp/1coc3_k--pit123",
+		"staging/wordpress-v2/WP_MIXPANEL_API_KEY",
 	}
 	for _, testString := range validTestStrings {
 		if err := ValidateInputKey(testString); err != nil {
@@ -18,8 +19,8 @@ func TestValidateInputKey(t *testing.T) {
 	invalidTestStrings := []string{
 		"staging/webapp",
 		"45678901jbf",
-		"asasa/12312/312313",
-		"1231/12312/312313",
+		"asasa/123!12/312313",
+		"1231/1231*2/312313",
 	}
 	for _, testString := range invalidTestStrings {
 		if err := ValidateInputKey(testString); err == nil {
@@ -44,8 +45,8 @@ func TestValidateInputKeyPattern(t *testing.T) {
 
 	invalidTestStrings := []string{
 		"45678901jbf",
-		"asasa/12312/312313",
-		"1231/12312/312313",
+		"asasa/123/12/312313",
+		"1231/123!12/312313",
 	}
 	for _, testString := range invalidTestStrings {
 		if err := ValidateInputKeyPattern(testString); err == nil {
@@ -80,7 +81,7 @@ func TestFindEnvironmentApplicationName(t *testing.T) {
 	invalidTestStrings := []string{
 		"stupid string",
 		"%/&/@#$%^&*",
-		"asdad/asdad1/1adads",
+		"asdad/asdad1!/1adads",
 	}
 	for _, testString := range invalidTestStrings {
 		if _, _, err := FindEnvironmentApplicationName(testString); err == nil {

--- a/version/version.go
+++ b/version/version.go
@@ -6,7 +6,7 @@ import (
 )
 
 // treasury version should be changed here
-const version = "0.4.0"
+const version = "0.4.1"
 
 // This will be filled in by the compiler.
 var (


### PR DESCRIPTION
case:
```
treasury import staging/wordpress-v2/ wordpress-v2/staging.secrets
Error: Given Key (staging/wordpress-v2/WP_MIXPANEL_API_KEY) does not match to defined regex.
```