### PR TITLE
Small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ In order to use SSM as a store, unset previously configured TREASURY_S3 environm
 In addition to the IAM credentials you'll need to specify the AWS region. You can specify the region either with an environment variable (example below), or directly in AWS configuration file `$HOME/.aws/config`. More about configuration [here](https://docs.aws.amazon.com/cli/latest/userguide/cli-config-files.html).
 
 ```sh
-export AWS_REGION=eu-west-1
+export AWS_DEFAULT_REGION=eu-west-1
 ```
 
 ## Installation
@@ -141,9 +141,6 @@ To import these values into s3:
 > treasury import development/application/ ./secrets.env
 Import successful
 ```
-
-Note: Using `=` in secret value is not allowed.
-      If secret value is equal to existing one, import skips this value. `--force` flag can be used to overwrite.
 
 ### Export secrets
 Assuming stored secrets pairs on treasury store

--- a/backend/s3/aws.go
+++ b/backend/s3/aws.go
@@ -22,12 +22,15 @@ func New(region, bucket string) (*Client, error) {
 	if bucket == "" {
 		return nil, errors.New("S3 bucket name is missing")
 	}
-	config := aws.Config{}
-	if region != "" {
-		config.Region = aws.String(region)
+	sessionOpts := session.Options{
+		SharedConfigState: session.SharedConfigEnable,
 	}
 
-	sess, err := session.NewSession(&config)
+	if region != "" {
+		sessionOpts.Config = aws.Config{Region: aws.String(region)}
+	}
+
+	sess, err := session.NewSessionWithOptions(sessionOpts)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create AWS session. Error: %s", err)
 	}

--- a/backend/ssm/aws.go
+++ b/backend/ssm/aws.go
@@ -16,7 +16,15 @@ type Client struct {
 
 // New returns clients for AWS services
 func New(region string) (*Client, error) {
-	sess, err := session.NewSession(&aws.Config{Region: aws.String(region)})
+	sessionOpts := session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+	}
+
+	if region != "" {
+		sessionOpts.Config = aws.Config{Region: aws.String(region)}
+	}
+
+	sess, err := session.NewSessionWithOptions(sessionOpts)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create AWS session. Error: %s", err)
 	}

--- a/client/export_test.go
+++ b/client/export_test.go
@@ -81,6 +81,7 @@ func TestClient_ExportMap(t *testing.T) {
 			wantResult: map[string]string{
 				test.ShortKey1: test.KeyValueMap[test.Key1],
 				test.ShortKey2: test.KeyValueMap[test.Key2],
+				test.ShortKey4: test.KeyValueMap[test.Key4],
 			},
 			wantErr: false,
 		},
@@ -141,8 +142,9 @@ func TestClient_ExportToTemplate(t *testing.T) {
 		{
 			name: "correct prefix key",
 			key:  "test/webapp/",
-			want: fmt.Sprintf("%s=%s\n%s=%s\n",
+			want: fmt.Sprintf("%s=%s\n%s=%s\n%s=%s\n",
 				test.ShortKey1, test.KeyValueMap[test.Key1],
+				test.ShortKey4, test.KeyValueMap[test.Key4],
 				test.ShortKey2, test.KeyValueMap[test.Key2],
 			),
 			wantErr: false,

--- a/client/import_test.go
+++ b/client/import_test.go
@@ -7,11 +7,25 @@ import (
 	test "github.com/AirHelp/treasury/test/backend"
 )
 
-func TestImport(t *testing.T) {
+func TestImportS3(t *testing.T) {
 	prefix := "test/webapp/"
 	dummyClientOptions := &client.Options{
 		Backend:      &test.MockBackendClient{},
 		S3BucketName: "fake_s3_bucket",
+	}
+	treasury, err := client.New(dummyClientOptions)
+	if err != nil {
+		t.Error(err)
+	}
+	if err := treasury.Import(prefix, "../test/resources/import.env.test", false); err != nil {
+		t.Error("Could not import secrets. Error: ", err.Error())
+	}
+}
+
+func TestImportSSM(t *testing.T) {
+	prefix := "test/webapp/"
+	dummyClientOptions := &client.Options{
+		Backend:      &test.MockBackendClient{},
 	}
 	treasury, err := client.New(dummyClientOptions)
 	if err != nil {

--- a/client/read_test.go
+++ b/client/read_test.go
@@ -85,9 +85,9 @@ func TestReadGroup(t *testing.T) {
 		responseSecrets int
 	}{
 		{
-			description:     "should return 2 secrets for test/webapp/",
+			description:     "should return 3 secrets for test/webapp/",
 			key:             filepath.Dir(test.Key1) + "/",
-			responseSecrets: 2,
+			responseSecrets: 3,
 		},
 		{
 			description:     "should return only 1 secret when full key path is given",

--- a/test/backend/test.go
+++ b/test/backend/test.go
@@ -16,12 +16,16 @@ const (
 	ShortKey2 = "user_api_pass"
 	Key3      = "test/cockpit/user_api_pass"
 	ShortKey3 = "user_api_pass"
+        Key4      = "test/webapp/some_key"
+	ShortKey4 = "some_key"
+
 )
 
 var KeyValueMap = map[string]string{
 	Key1: "as9@#$%^&*(/2hdiwnf",
 	Key2: "as9@#$&*(/2saddsahdiwnf",
 	Key3: "#$&*(/2saddsah&as",
+	Key4: "value=with=multiple=equal=signs==",
 }
 
 // MockBackendClient fake backendAPI

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -59,7 +59,7 @@ func ReadSecrets(secretsFile string) (map[string]string, error) {
 	for scanner.Scan() {
 		line := strings.Trim(scanner.Text(), " ")
 		if !strings.HasPrefix(line, "#") {
-			keyVal := strings.Split(line, "=")
+			keyVal := strings.SplitN(line, "=", 2)
 			if len(keyVal) == 2 {
 				secrets[keyVal[0]] = keyVal[1]
 			}

--- a/version/version.go
+++ b/version/version.go
@@ -6,7 +6,7 @@ import (
 )
 
 // treasury version should be changed here
-const version = "0.4.2"
+const version = "0.4.3"
 
 // This will be filled in by the compiler.
 var (


### PR DESCRIPTION
Changelog:
- fixed importing key issue when value has `=` sign(s) in secret
- support for SharedConfigState (https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/sessions.html#sessions-with-shared-config). `-r` parameter is no longer needed if region is set in `~/.aws/config` or `AWS_DEFAULT_REGION`
- updated README.md