### PR TITLE
Bump Treasury version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,7 @@ module github.com/AirHelp/treasury
 
 require (
 	github.com/aws/aws-sdk-go v1.19.49
-	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/spf13/cobra v0.0.5
-	github.com/spf13/pflag v1.0.3 // indirect
 	github.com/stretchr/testify v1.3.0 // indirect
 	golang.org/x/net v0.0.0-20190206173232-65e2d4e15006 // indirect
-	golang.org/x/text v0.3.0 // indirect
 )

--- a/version/version.go
+++ b/version/version.go
@@ -6,7 +6,7 @@ import (
 )
 
 // treasury version should be changed here
-const version = "0.5.1"
+const version = "0.5.2"
 
 // This will be filled in by the compiler.
 var (


### PR DESCRIPTION
Changelog:
* Bumps golang from 1.11-alpine to 1.12.6-alpine https://github.com/AirHelp/treasury/pull/48
* Bump github.com/aws/aws-sdk-go from 1.16.2 to 1.19.49 https://github.com/AirHelp/treasury/pull/47
* Bump github.com/spf13/cobra from 0.0.3 to 0.0.5 https://github.com/AirHelp/treasury/pull/43



bats tests:
```
bats test/bats/tests.bats
 ✓ Check that the treasury binary is available
 ✓ usage
 ✓ help
 ✓ write
 ✓ write second
 ✓ write second not forced
 ✓ write second forced
 ✓ write-wrong-data
 ✓ write random key
 ✓ read
 ✓ read-with-valid-region
 ✓ read-with-wrong-region
 ✓ read-wrong-data
 ✓ export single
 ✓ export all
 ✓ import forced
 ✓ read imported key3
 ✓ read imported key4
 ✓ template
 ✓ template-and-var-append
 ✓ template-and-var-append-multiple-variables
 ✓ template-and-var-append-bad-input
 ✓ template wrong key
 ✓ check version

24 tests, 0 failures
```