### PR TITLE
[DOT-665] Add exporting from env using interpolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Treasury is a very simple tool for managing secrets. It uses Amazon S3 or SSM ([
       - [read](#read)
       - [readFromEnv](#readfromenv)
       - [export](#export)
+      - [exportFromEnv](#exportfromenv)
       - [exportMap](#exportmap)
   - [Setting up the infrastructure](#setting-up-the-infrastructure)
     - [IAM Policy for S3 store](#iam-policy-for-s3-store)
@@ -239,10 +240,29 @@ Returns single value for given key in specified environment
 
 
 #### export
-Returns all values for a given path in `key=value` format
+**DEPRECATED (please use [exportFromEnv](#exportFromEnv))** Returns all values for a given path in `key=value` format
 
 ```
 {{ export "development/treasury/" }}
+```
+
+will generate:
+```
+key1=secret1
+key2=secret2
+key3=secret3
+key4=secret4
+```
+
+#### exportFromEnv
+Returns all values from given environment and given key in `key=value` format
+
+```
+{{ exportFromEnv "development" "treasury" }}
+
+# or using interpolation
+
+{{ exportFromEnv .Environment "treasury" }}
 ```
 
 will generate:

--- a/client/read.go
+++ b/client/read.go
@@ -36,6 +36,7 @@ func (c *Client) ReadValue(key string) (string, error) {
 	return secret.Value, nil
 }
 
+// ReadFromEnv returns value of given key in specified env.
 func (c *Client) ReadFromEnv(env, key string) (string, error) {
 	return c.ReadValue(fmt.Sprintf("%s/%s", env, key))
 }

--- a/client/template.go
+++ b/client/template.go
@@ -2,10 +2,13 @@ package client
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"text/template"
+
+	"github.com/AirHelp/treasury/utils"
 )
 
 const (
@@ -27,12 +30,19 @@ func readTemplate(filePath string) (string, error) {
 func (c *Client) renderTemplate(templateText string, appendMap, envMap map[string]string) (templateResultBuffer bytes.Buffer, err error) {
 	// Create a FuncMap with which to register the function.
 	funcMap := template.FuncMap{
-		// The name "read" is what the function will be called in the template text.
-		"read":        c.ReadValue,
 		"readFromEnv": c.ReadFromEnv,
 		"exportMap":   c.ExportMap,
+		// The name "read" is what the function will be called in the template text.
+		"read": func(key string) (string, error) {
+			utils.DeprecationWarning("`read` template function is deprecated, please use `readFromEnv` instead.")
+			return c.ReadValue(key)
+		},
 		"export": func(key string) (string, error) {
+			utils.DeprecationWarning("`export` template function is deprecated, please use `exportFromEnv` instead.")
 			return c.ExportToTemplate(key, appendMap)
+		},
+		"exportFromEnv": func(environment, key string) (string, error) {
+			return c.ExportToTemplate(fmt.Sprintf("%s/%s/", environment, key), appendMap)
 		},
 	}
 	// Create a template, add the function map, and parse the text.

--- a/test/bats/tests.bats
+++ b/test/bats/tests.bats
@@ -176,6 +176,18 @@ invalid_aws_region=us-west-1
   [[ ${lines[0]} =~ "Error" ]]
 }
 
+@test "template-deprecations" {
+  run $treasury template --src test/resources/bats-source-deprecations.secret.tpl --dst test/output/bats-output.secret
+  [ $status -eq 0 ]
+  [[ ${lines[0]} == "[Deprecation warning] \`read\` template function is deprecated, please use \`readFromEnv\` instead." ]]
+  [[ ${lines[1]} == "[Deprecation warning] \`export\` template function is deprecated, please use \`exportFromEnv\` instead." ]]
+  [[ ${lines[2]} == "File with secrets successfully generated" ]]
+  run grep "APPLICATION_SECRET_KEY=secret2" test/output/bats-output.secret
+  [ $status -eq 0 ]
+  run grep "key4=secret4" test/output/bats-output.secret
+  [ $status -eq 0 ]
+}
+
 @test "write file content to treasury key" {
   run $treasury write development/treasury/key5 test/resources/test_file --file
   [ $status -eq 0 ]

--- a/test/resources/bats-source-deprecations.secret.tpl
+++ b/test/resources/bats-source-deprecations.secret.tpl
@@ -1,0 +1,4 @@
+APPLICATION_SECRET_KEY={{ read "development/treasury/key2" }}
+
+# export secrets as key=value
+{{ export "development/treasury/" }}

--- a/test/resources/bats-source.secret.tpl
+++ b/test/resources/bats-source.secret.tpl
@@ -1,8 +1,8 @@
-APPLICATION_SECRET_KEY={{ read "development/treasury/key2" }}
+APPLICATION_SECRET_KEY={{ readFromEnv "development" "treasury/key2" }}
 
 # export secrets in flexible way
 {{ range $key, $value := exportMap "development/treasury/" }}
 {{ $key }}={{ $value }}{{ end }}
 
 # export secrets as key=value
-{{ export "development/treasury/" }}
+{{ exportFromEnv "development" "treasury" }}

--- a/test/resources/bats-wrong-source.secret.tpl
+++ b/test/resources/bats-wrong-source.secret.tpl
@@ -1,1 +1,1 @@
-APPLICATION_SECRET_KEY={{ read "development/treasury/wrong_application_key" }}
+APPLICATION_SECRET_KEY={{ readFromEnv "development" "treasury/wrong_application_key" }}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -78,3 +78,8 @@ func ReadSecrets(secretsFile string) (map[string]string, error) {
 	}
 	return secrets, nil
 }
+
+// Prints deprecation warning to stdout
+func DeprecationWarning(body string) {
+	fmt.Printf("[Deprecation warning] %s\n", body)
+}


### PR DESCRIPTION

Requestor/Jira: continuation of https://jira.airhelp.com/browse/DOT-665
Risk (low/med/high): ?
Tested (yes/no): yes
Description/Why:

1. Adds possibility to export whole collection from given environment and key easily using variable interpolation
2. Deprecates old `export` method
3. Adds deprecation warning for `read` and `export` template functions
