### PR TITLE
DOT-1527 chore: Upgrade Go to 1.17

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,10 @@ require (
 	github.com/spf13/cobra v0.0.7
 )
 
-go 1.16
+require (
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/spf13/pflag v1.0.3 // indirect
+)
+
+go 1.17


### PR DESCRIPTION
Requestor/Jira: DOT-1527
Risk (low/med/high): low
Tested (yes/no): no
Description/Why:

New Go release.