### PR TITLE
chore: Remove deprecation warnings from stdout

### DIFF
--- a/client/template.go
+++ b/client/template.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"text/template"
-
-	"github.com/AirHelp/treasury/utils"
 )
 
 const (
@@ -34,11 +32,9 @@ func (c *Client) renderTemplate(templateText string, appendMap, envMap map[strin
 		"exportMap":   c.ExportMap,
 		// The name "read" is what the function will be called in the template text.
 		"read": func(key string) (string, error) {
-			utils.DeprecationWarning("`read` template function is deprecated, please use `readFromEnv` instead.")
 			return c.ReadValue(key)
 		},
 		"export": func(key string) (string, error) {
-			utils.DeprecationWarning("`export` template function is deprecated, please use `exportFromEnv` instead.")
 			return c.ExportToTemplate(key, appendMap)
 		},
 		"exportFromEnv": func(environment, key string) (string, error) {

--- a/test/bats/tests.bats
+++ b/test/bats/tests.bats
@@ -176,18 +176,6 @@ invalid_aws_region=us-west-1
   [[ ${lines[0]} =~ "Error" ]]
 }
 
-@test "template-deprecations" {
-  run $treasury template --src test/resources/bats-source-deprecations.secret.tpl --dst test/output/bats-output.secret
-  [ $status -eq 0 ]
-  [[ ${lines[0]} == "[Deprecation warning] \`read\` template function is deprecated, please use \`readFromEnv\` instead." ]]
-  [[ ${lines[1]} == "[Deprecation warning] \`export\` template function is deprecated, please use \`exportFromEnv\` instead." ]]
-  [[ ${lines[2]} == "File with secrets successfully generated" ]]
-  run grep "APPLICATION_SECRET_KEY=secret2" test/output/bats-output.secret
-  [ $status -eq 0 ]
-  run grep "key4=secret4" test/output/bats-output.secret
-  [ $status -eq 0 ]
-}
-
 @test "write file content to treasury key" {
   run $treasury write development/treasury/key5 test/resources/test_file --file
   [ $status -eq 0 ]

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -78,8 +78,3 @@ func ReadSecrets(secretsFile string) (map[string]string, error) {
 	}
 	return secrets, nil
 }
-
-// Prints deprecation warning to stdout
-func DeprecationWarning(body string) {
-	fmt.Printf("[Deprecation warning] %s\n", body)
-}

--- a/version/version.go
+++ b/version/version.go
@@ -6,7 +6,7 @@ import (
 )
 
 // treasury version should be changed here
-const version = "v0.10.0"
+const version = "v0.10.1"
 
 // This will be filled in by the compiler.
 var (


### PR DESCRIPTION
Requestor/Issue: Me
Risk (low/med/high): low
Tested (yes/no): no
Description/Why:
Those deprecation warnings generate lot of non json log entries in our tools. Since we don't plan to remove it, I don't see a point of keeping it here.
