### PR TITLE
chore: Apply fixes to build treasury on colima

### DIFF
--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -1,6 +1,7 @@
 FROM golang:1.20
 
 ENV CGO_ENABLED=0
+ENV GOPATH=''
 
 COPY go.mod go.sum ./
 RUN go mod download

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -2,6 +2,7 @@ version: '3.1'
 
 services:
   tests:
+    platform: linux/amd64
     build:
       context: .
       dockerfile: Dockerfile-test

--- a/go.mod
+++ b/go.mod
@@ -11,4 +11,4 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 )
 
-go 1.19
+go 1.20


### PR DESCRIPTION
Requestor/Issue: Me
Risk (low/med/high): low
Tested (yes/no): yes, the test release has been made
Description/Why:
The platform to docker-compose added because of error:
```
docker-compose -f docker-compose.test.yml run --rm tests gofmt -s -w .
Error response from daemon: image with reference treasury-tests was found but does not match the specified platform: wanted linux/amd64, actual: linux/arm64/v8
```

The GOPATH needs to be empty to solve:
```
$GOPATH/go.mod exists but should not
```
