### PR TITLE
Bump patch version to retrigger homebrew deploy

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -6,7 +6,7 @@ import (
 )
 
 // treasury version should be changed here
-const version = "v0.11.0"
+const version = "v0.11.1"
 
 // This will be filled in by the compiler.
 var (


### PR DESCRIPTION
Requestor/Issue: jenkins
Risk (low/med/high): low
Tested (yes/no): no changes
Description/Why:

After failed previous release the binary was recreated in S3 manually. Its SHA mismatch though. This PR bumps patch version to force new version release.