### PR TITLE
Revert "Bump patch version to retrigger homebrew deploy"

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -6,7 +6,7 @@ import (
 )
 
 // treasury version should be changed here
-const version = "v0.11.1"
+const version = "v0.11.0"
 
 // This will be filled in by the compiler.
 var (


### PR DESCRIPTION
Reverting as release is not possible currently