### PR TITLE
fix(config): goreleaser require configuration update

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 # This is an example goreleaser.yaml file with some sane defaults.
 # Make sure to check the documentation at http://goreleaser.com
 before:
@@ -37,7 +39,7 @@ archives:
 checksum:
   name_template: "checksums.txt"
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  version_template: "{{ .Tag }}-next"
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
Requestor/Issue: @tcharewicz 
Risk (low/med/high): low
Tested (yes/no): yes, by `goreleaser check` command
Description/Why: This pull request change configuration for goreleaser.
- Before change `check` command shows:
```bash
❯ goreleaser check
  • only configurations files on  version: 2  are supported, yours is  version: 0 , please update your configuration
  • checking                                 path=.goreleaser.yml
  • DEPRECATED:  snapshot.name_template  should not be used anymore, check https://goreleaser.com/deprecations#snapshotnametemplate for more info
  • .goreleaser.yml                                  error=configuration is valid, but uses deprecated properties
  ⨯ command failed                                   error=1 out of 1 configuration file(s) have issues
```

- After change `check` command shows:
```bash
❯ goreleaser check
  • checking                                 path=.goreleaser.yml
  • 1 configuration file(s) validated
  • thanks for using goreleaser!
```
