### PR TITLE
Fix Treasury write operation for new SSM parameters

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -6,7 +6,7 @@ import (
 )
 
 // treasury version should be changed here
-const version = "v0.13.0"
+const version = "v0.13.1"
 
 // This will be filled in by the compiler.
 var (


### PR DESCRIPTION
Requestor/Issue: @PiotrWaluszek
Risk (low/med/high): low
Tested (yes/no): no
Description/Why: This PR fixes a bug reported in [TSTDVPS-110](https://airhelp.atlassian.net/browse/TSTDVPS-110) where Treasury fails to write new SSM parameters. The error occurs due to incorrect handling of the "ParameterNotFound" response from SSM. We've updated the error handling logic to correctly process this scenario, allowing for the creation of new parameters while maintaining existing functionality for S3 operations.

