### PR TITLE
fix(treasury): invalid SSM client construction

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -36,7 +36,7 @@ func New(options Options) (BackendAPI, error) {
 	case s3Name:
 		return s3.New(options.Region, options.S3BucketName)
 	case ssmName:
-		return ssm.New(options.Region, options.AWSConfig)
+		return ssm.New(options.AWSConfig)
 	}
 	return nil, errors.New("invalid backend")
 }

--- a/backend/ssm/aws.go
+++ b/backend/ssm/aws.go
@@ -2,10 +2,8 @@ package ssm
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 )
 
@@ -21,13 +19,8 @@ type Client struct {
 	svc SSMClientInterface
 }
 
-func New(region string, awsConfig aws.Config) (*Client, error) {
-	cfg, err := config.LoadDefaultConfig(context.Background(), config.WithRegion(region))
-	if err != nil {
-		return nil, fmt.Errorf("failed to load AWS configuration. Error: %s", err)
-	}
-
+func New(awsConfig aws.Config) (*Client, error) {
 	return &Client{
-		svc: ssm.NewFromConfig(cfg),
+		svc: ssm.NewFromConfig(awsConfig),
 	}, nil
 }

--- a/backend/ssm/aws_test.go
+++ b/backend/ssm/aws_test.go
@@ -34,7 +34,7 @@ func TestNew(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := ssm.New(tt.region, tt.config)
+			_, err := ssm.New(tt.config)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("New() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/version/version.go
+++ b/version/version.go
@@ -6,7 +6,7 @@ import (
 )
 
 // treasury version should be changed here
-const version = "v0.13.1"
+const version = "v0.14.0"
 
 // This will be filled in by the compiler.
 var (


### PR DESCRIPTION
Requestor/Issue: https://github.com/AirHelp/treasury/issues/241
Risk (low/med/high): low
Tested (yes/no): yes locally
Description/Why: After aws-sdk-upgrade https://github.com/AirHelp/treasury/pull/220/files#diff-b5cb898dcbfe4bf8f75f111bbfe93c26eea7be7af1d1c3dccbb95a12193dc315, aws client had invalid configuration. The config that was received as a parameter was ignored and the default client was loaded.


resolves: https://github.com/AirHelp/treasury/issues/241