### PR TITLE
Bump golang from 1.23 to 1.24

### DIFF
--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -1,4 +1,4 @@
-FROM golang:1.23
+FROM golang:1.24
 
 ENV CGO_ENABLED=0
 ENV GOPATH=''

--- a/go.mod
+++ b/go.mod
@@ -44,4 +44,4 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 )
 
-go 1.22
+go 1.24


### PR DESCRIPTION
Requestor/Issue: @kszarek 
Risk (low/med/high): low
Tested (yes/no): yes
Description/Why: Mosty, to solve the issue with CodeQL https://github.com/AirHelp/treasury/security/code-scanning/tools/CodeQL/status/configurations/automatic/b3a321ea6e3f94cf098d8356913e04479c2a0305928525bd632b6fe39b4349c5
![Screenshot 2025-02-17 at 10 26 04](https://github.com/user-attachments/assets/c56b3684-4272-4171-a46a-7f7f11192176)
