### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,4 +1,6 @@
 name: tests
+permissions:
+  contents: read
 
 on: pull_request
 


### PR DESCRIPTION
Potential fix for [https://github.com/AirHelp/treasury/security/code-scanning/1](https://github.com/AirHelp/treasury/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow or the specific job to restrict the `GITHUB_TOKEN` to the minimum required privileges. For this workflow, which only checks out code and runs Go tests and vetting, only read access to repository contents is needed. The best fix is to add `permissions: contents: read` at the top level of the workflow (just after the `name:` and before `on:`), so it applies to all jobs unless overridden. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
