### PR TITLE
Move version of Go to go.mod

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version-file: 'go.mod'
 
       - name: Download dependencies
         run: go mod download

--- a/go.mod
+++ b/go.mod
@@ -45,4 +45,4 @@ require (
 	github.com/spf13/pflag v1.0.6 // indirect
 )
 
-go 1.24
+go 1.25


### PR DESCRIPTION
Requestor/Issue: @kszarek 
Risk (low/med/high): low
Tested (yes/no): yes
Description/Why: This pull request updates the Go version used in the project to 1.25. The workflow now references the Go version specified in `go.mod`, ensuring consistency between local development and CI.